### PR TITLE
Remove previous buttons when setting new tags list

### DIFF
--- a/Tags/Classes/TagsView.swift
+++ b/Tags/Classes/TagsView.swift
@@ -117,6 +117,10 @@ public class TagsView: UIView {
     @IBInspectable
     public var tags: String = "" {
         didSet {
+            for element in self._tagArray {
+                element.removeConstraint()
+                element.removeFromSuperview()
+            }
             self._tagArray.removeAll()
             self.append(contentsOf: self.tags.components(separatedBy: ",").filter({ $0 != "" }))
         }


### PR DESCRIPTION
Hello @pikachu987,

I figure out that cleaning `_tagArray` is not enough to show new tags list. 

When you call:
`tagsView = "tag1,tag2,tag3"`
and a bit later
`tagsView = "tag3,tag4,tag5"`
tags view will have 3 ghost tag buttons in left upper corner below new buttons.